### PR TITLE
Treat docker containers as machines

### DIFF
--- a/lib/webminer-database.php
+++ b/lib/webminer-database.php
@@ -98,9 +98,10 @@ class Database {
 	}
 
 	/**
-     * Set the container for the request
+     * Set the machine for the container
+     * Treat docker containers as machines
      */
-	public function setRequestContainer($request,$server,$container) {
+	public function setRequestMachine($request,$server,$container) {
 		DB::update('requests', array(
 			'docker_server' => $server,
 			'container' => $container


### PR DESCRIPTION
To allow for modular infrastructure extensibility create a single method for handling the requests going to a "machine" that consists of a running JVM
